### PR TITLE
Add containerd labels as labels on prometheus metrics

### DIFF
--- a/pkg/kubelet/kuberuntime/labels.go
+++ b/pkg/kubelet/kuberuntime/labels.go
@@ -98,6 +98,10 @@ func newPodAnnotations(pod *v1.Pod) map[string]string {
 // newContainerLabels creates container labels from v1.Container and v1.Pod.
 func newContainerLabels(container *v1.Container, pod *v1.Pod) map[string]string {
 	labels := map[string]string{}
+	for k, v := range pod.Labels {
+		labels[k] = v
+	}
+
 	labels[types.KubernetesPodNameLabel] = pod.Name
 	labels[types.KubernetesPodNamespaceLabel] = pod.Namespace
 	labels[types.KubernetesPodUIDLabel] = string(pod.UID)

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -969,6 +969,14 @@ func containerPrometheusLabelsFunc(s stats.Provider) metrics.ContainerLabelsFunc
 			"namespace":        namespace,
 			"container":        containerName,
 		}
+
+		// This behavior is borrowed from CAdvisor's default labeling behavior
+		// https://github.com/google/cadvisor/blob/master/metrics/prometheus.go#L1786-L1788
+		const ContainerLabelPrefix string = "container_label_"
+		for k, v := range c.Spec.Labels {
+			set[ContainerLabelPrefix+k] = v
+		}
+
 		return set
 	}
 }


### PR DESCRIPTION
The Kubelet currently hard codes a set of labels for Prometheus metrics.  This is different than CAdvisor default behavior which injects Container labels onto the prometheus metrics for those containers.  We need this behavior to add custom metadata associated with containers such as Spinnaker "application" and "stack" information.