### PR TITLE
Relax restriction for usernamespace with Pod mode

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1822,8 +1822,8 @@ func (kl *Kubelet) UserNamespaceForPod(pod *v1.Pod) (runtimeapi.NamespaceMode, e
 		}
 		return runtimeapi.NamespaceMode_NODE, nil
 	case UsernsPod:
-		if kl.enableHostUserNamespace(pod) {
-			return runtimeapi.NamespaceMode_NODE, fmt.Errorf("PodSpec doesn't allow to use 'Pod' mode for user namespaces")
+		if hasHostNamespace(pod) {
+			kl.recorder.Eventf(pod, v1.EventTypeWarning, "UserNsWarning", "User namespace mode is 'Pod' and PodSpec shares a host namespace.")
 		}
 		if !runtimeEnabled {
 			return runtimeapi.NamespaceMode_NODE, fmt.Errorf("runtime doesn't support user namespaces")


### PR DESCRIPTION
There are some features that *could* be not compatible with user namespaces:
- hostpath volumes
- PVC
- sharing other host namespaces
- some capabilities

The current code forbids to use 'Pod' mode when one of those features is present
on the PodSpec. This commit relaxes that logic and replaces it by a warning only
for the case where host namespaces are shared given that it's the only case
that could present issues when creating the container.
