### PR TITLE
Don't periodically chown volumes for user namespaces

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -321,7 +321,7 @@ func (m *kubeGenericRuntimeManager) Status() (*kubecontainer.RuntimeStatus, erro
 // GetRuntimeConfigInfo returns runtime configuration details cached at runtime manager
 // nil is returned if the runtime doesn't support this method.
 func (m *kubeGenericRuntimeManager) GetRuntimeConfigInfo() (*kubecontainer.RuntimeConfigInfo, error) {
-	if m.runtimeConfigCached  {
+	if m.runtimeConfigCached {
 		return m.runtimeConfig, nil
 	}
 	runtimeConfig, err := m.runtimeService.GetRuntimeConfigInfo()
@@ -1089,10 +1089,6 @@ func (m *kubeGenericRuntimeManager) SyncPod(pod *v1.Pod, podStatus *kubecontaine
 		klog.Error(message)
 		configPodSandboxResult.Fail(kubecontainer.ErrConfigPodSandbox, message)
 		return
-	}
-
-	if userns, err := m.runtimeHelper.UserNamespaceForPod(pod); err == nil && userns == runtimeapi.NamespaceMode_POD {
-		m.chownAllFilesAt(m.runtimeHelper.GetPodVolumesDir(pod.UID))
 	}
 
 	// Helper containing boilerplate common to starting all types of containers.


### PR DESCRIPTION
This periodic chown makes everything in shared volumes
owned by root. This is very frustrating for log volumes
where a file may be created as say `www-data`, but then
chowned by this sync process later to root.

The downside is that, with user namespaces, volumes are created
with very lax permissions:

    drwxrwxrwx    2 nobody  nogroup   68 Feb  9 22:00 logs

Maybe should do a one time chown instead of a perodic one?
Or maybe it is just left as an exercise to the pod owner to
set their own permissions?
(I think I vote the latter, because it is nice to be able to run containers
as non-root, and with permissions like that, they will actually
be able to use volumes)
